### PR TITLE
Nye serie og variant-endepunkt

### DIFF
--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistration.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistration.kt
@@ -259,5 +259,6 @@ data class ProductRegistrationDTOV2(
     val productData: ProductData,
     val agreements: List<AgreementInfo>,
     val version: Long?,
-    val isExpired: Boolean
+    val isExpired: Boolean,
+    val isPublished: Boolean
 )

--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistration.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistration.kt
@@ -237,3 +237,27 @@ data class ProductRegistrationDryRunDTO(
     val agreements: List<AgreementInfo> = emptyList(),
     val version: Long? = 0L,
 )
+
+
+data class UpdateProductRegistrationDTO(
+    val hmsArtNr: String?,
+    val articleName: String,
+    val accessory: Boolean,
+    val sparePart: Boolean,
+    val productData: ProductData,
+    val agreements: List<AgreementInfo>,
+)
+
+data class ProductRegistrationDTOV2(
+    val id: UUID,
+    val hmsArtNr: String?,
+    val supplierRef: String,
+    val articleName: String,
+    val accessory: Boolean,
+    val sparePart: Boolean,
+    val created: LocalDateTime,
+    val productData: ProductData,
+    val agreements: List<AgreementInfo>,
+    val version: Long?,
+    val isExpired: Boolean
+)

--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationAdminApiController.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationAdminApiController.kt
@@ -31,7 +31,6 @@ import no.nav.hm.grunndata.register.error.BadRequestException
 import no.nav.hm.grunndata.register.product.batch.ProductExcelExport
 import no.nav.hm.grunndata.register.product.batch.ProductExcelImport
 import no.nav.hm.grunndata.register.security.Roles
-import no.nav.hm.grunndata.register.security.supplierId
 import no.nav.hm.grunndata.register.series.SeriesGroupDTO
 import no.nav.hm.grunndata.register.supplier.SupplierRegistrationService
 import org.apache.commons.io.output.ByteArrayOutputStream
@@ -133,7 +132,7 @@ class ProductRegistrationAdminApiController(
     }
 
     @Post("/draftWithV3/{seriesUUID}")
-    suspend fun draftProductWithV2(
+    suspend fun draftProductWithV3(
         @PathVariable seriesUUID: UUID,
         @Body draftWith: DraftVariantDTO,
         authentication: Authentication,

--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationAdminApiController.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationAdminApiController.kt
@@ -31,6 +31,7 @@ import no.nav.hm.grunndata.register.error.BadRequestException
 import no.nav.hm.grunndata.register.product.batch.ProductExcelExport
 import no.nav.hm.grunndata.register.product.batch.ProductExcelImport
 import no.nav.hm.grunndata.register.security.Roles
+import no.nav.hm.grunndata.register.security.supplierId
 import no.nav.hm.grunndata.register.series.SeriesGroupDTO
 import no.nav.hm.grunndata.register.supplier.SupplierRegistrationService
 import org.apache.commons.io.output.ByteArrayOutputStream
@@ -123,7 +124,23 @@ class ProductRegistrationAdminApiController(
         authentication: Authentication,
     ): HttpResponse<ProductRegistrationDTO> = try {
         HttpResponse.ok(
-            productRegistrationService.createDraftWithV2(seriesUUID, draftWith, supplierId, authentication),
+            productRegistrationService.createDraftWithV2(seriesUUID, draftWith, authentication),
+        )
+    } catch (e: DataAccessException) {
+        throw BadRequestException(e.message ?: "Error creating draft")
+    } catch (e: Exception) {
+        throw BadRequestException("Error creating draft")
+    }
+
+    @Post("/draftWithV3/{seriesUUID}")
+    suspend fun draftProductWithV2(
+        @PathVariable seriesUUID: UUID,
+        @Body draftWith: DraftVariantDTO,
+        authentication: Authentication,
+    ): HttpResponse<ProductRegistrationDTO> = try {
+
+        HttpResponse.ok(
+            productRegistrationService.createDraftWithV2(seriesUUID, draftWith, authentication),
         )
     } catch (e: DataAccessException) {
         throw BadRequestException(e.message ?: "Error creating draft")
@@ -232,6 +249,51 @@ class ProductRegistrationAdminApiController(
                 throw BadRequestException("Got exception while updating product $id")
             }
         }
+
+
+    @Put("/to-expired/{id}")
+    suspend fun setPublishedSeriesToInactive(
+        @PathVariable id: UUID,
+        authentication: Authentication,
+    ): HttpResponse<ProductRegistrationDTO> {
+        val productToUpdate = productRegistrationService.findById(id) ?: return HttpResponse.notFound()
+
+        val updatedProduct =
+            productToUpdate.copy(
+                registrationStatus = RegistrationStatus.INACTIVE,
+                expired = LocalDateTime.now(),
+                updated = LocalDateTime.now(),
+                updatedBy = REGISTER,
+                updatedByUser = authentication.name,
+            )
+
+        val updated =
+            productRegistrationService.saveAndCreateEventIfNotDraftAndApproved(updatedProduct, isUpdate = true)
+
+        return HttpResponse.ok(updated)
+    }
+
+    @Put("/to-active/{id}")
+    suspend fun setPublishedSeriesToActive(
+        @PathVariable id: UUID,
+        authentication: Authentication,
+    ): HttpResponse<ProductRegistrationDTO> {
+        val productToUpdate = productRegistrationService.findById(id) ?: return HttpResponse.notFound()
+
+        val updatedProduct =
+            productToUpdate.copy(
+                registrationStatus = RegistrationStatus.ACTIVE,
+                expired = LocalDateTime.now().plusYears(10),
+                updated = LocalDateTime.now(),
+                updatedBy = REGISTER,
+                updatedByUser = authentication.name,
+            )
+
+        val updated =
+            productRegistrationService.saveAndCreateEventIfNotDraftAndApproved(updatedProduct, isUpdate = true)
+
+        return HttpResponse.ok(updated)
+    }
 
     @Delete("/{id}")
     suspend fun deleteProduct(

--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationService.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationService.kt
@@ -555,6 +555,7 @@ open class ProductRegistrationService(
             agreements = agreeements.map { it.toAgreementInfo() },
             version = version,
             isExpired = expired?.let { it < LocalDateTime.now() } ?: false,
+            isPublished = published?.let { it < LocalDateTime.now() } ?: false,
         )
     }
 

--- a/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistration.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistration.kt
@@ -10,7 +10,6 @@ import java.time.LocalDateTime
 import java.util.Locale
 import java.util.UUID
 import no.nav.hm.grunndata.rapid.dto.AdminStatus
-import no.nav.hm.grunndata.rapid.dto.AgreementInfo
 import no.nav.hm.grunndata.rapid.dto.CompatibleWith
 import no.nav.hm.grunndata.rapid.dto.DraftStatus
 import no.nav.hm.grunndata.rapid.dto.IsoCategoryDTO
@@ -22,11 +21,8 @@ import no.nav.hm.grunndata.rapid.dto.SeriesStatus
 import no.nav.hm.grunndata.register.REGISTER
 import no.nav.hm.grunndata.register.event.EventPayload
 import no.nav.hm.grunndata.register.product.MediaInfoDTO
-import no.nav.hm.grunndata.register.product.ProductData
 import no.nav.hm.grunndata.register.product.ProductRegistrationDTOV2
 import no.nav.hm.grunndata.register.product.toRapidMediaInfo
-import no.nav.hm.grunndata.register.supplier.SupplierRegistration
-import no.nav.hm.grunndata.register.supplier.SupplierRegistrationDTO
 
 @MappedEntity("series_reg_v1")
 data class SeriesRegistration(
@@ -205,7 +201,7 @@ fun toSeriesRegistrationDTOV2(
     variants = productRegistrationDTOs,
     version = seriesRegistration.version,
     isExpired = seriesRegistration.expired < LocalDateTime.now(),
-    isPublised = seriesRegistration.published?.let { it < LocalDateTime.now() } ?: false,
+    isPublished = seriesRegistration.published?.let { it < LocalDateTime.now() } ?: false,
     inAgreement = inAgreement
 )
 
@@ -294,6 +290,6 @@ data class SeriesRegistrationDTOV2(
     val variants: List<ProductRegistrationDTOV2>,
     val version: Long?,
     val isExpired: Boolean,
-    val isPublised: Boolean,
+    val isPublished: Boolean,
     val inAgreement: Boolean,
 )

--- a/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistration.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistration.kt
@@ -136,12 +136,6 @@ data class SeriesRegistrationDTO(
             status != SeriesStatus.DELETED &&
             published != null
     }
-
-    fun isPendingApproval(): Boolean {
-        return draftStatus == DraftStatus.DONE &&
-                adminStatus == AdminStatus.PENDING &&
-                status != SeriesStatus.DELETED
-    }
 }
 
 fun SeriesRegistration.toDTO() =

--- a/src/test/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationApiTest.kt
+++ b/src/test/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationApiTest.kt
@@ -60,8 +60,8 @@ class ProductRegistrationApiTest(
     fun createUserSupplierAndSeries() {
         val name1 = "25cfec1d-fc9b-474e-ab3a-7c997fbc8e73"
         val name2 = "ba38e5a7-fce3-46ad-9548-a874d967b2a2"
-        val supplierId = UUID.randomUUID()
-        val supplierId2 = UUID.randomUUID()
+        val supplierId = UUID.fromString("ec7b1c83-f4d6-424f-9513-5a52d6cbd3a3")
+        val supplierId2 = UUID.fromString("b6922b7d-5f9e-43dc-815e-971d810c9a87")
         runBlocking {
             if (supplierRegistrationService.findByName(name1) == null) {
                 supplierRegistrationService.save(


### PR DESCRIPTION
I første omgang nye endepunkt for å hente data. Har med litt halvferdig logikk for å oppdatere data også, men å gjøre det ferdig blir neste steg.

I frontenden i dag gjør vi fire? kall for å få all infoen vi trenger for å vise et produkt, har samlet alt i ett kall.

Har slått sammen de tre statusene til én, siden frontendlogikken er ganske rotete rundt dette:
`enum class EditStatus {
    EDITABLE,
    PENDING_APPROVAL,
    REJECTED,
    DONE;
}`
Litt usikker på DONE, men fant ikke noe bedre ord for å beskrive at det man ser i adminreg er likt det man ser på finnhjelpemiddel, aka at det ikke er en edit på gang.

isPublished og isExpired er egne booleans siden de er uanhengive av EditStatus.

Har bare lagt til nye greier uten å rydde i det gamle, for å ikke brekke noe, så det er litt rotete. Enklere å rydde etter at frontendene har begynt å bruke de nye endepunktene