### PR TITLE
Rydding av product/variant-koden

### DIFF
--- a/src/main/kotlin/no/nav/hm/grunndata/register/error/BadRequestErrorHandler.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/error/BadRequestErrorHandler.kt
@@ -39,6 +39,7 @@ class BadRequestErrorHandler : ExceptionHandler<BadRequestException, HttpRespons
                         .body(createMessage(error))
 
                 ErrorType.UNKNOWN -> HttpResponse.serverError(createMessage(error))
+                ErrorType.UNAUTHORIZED -> HttpResponse.unauthorized()
             }
         if (error.type != ErrorType.NOT_FOUND) {
             LOG.error(response.body().toString())
@@ -128,6 +129,7 @@ enum class ErrorType {
     CONFLICT,
     NOT_FOUND,
     UNKNOWN,
+    UNAUTHORIZED
 }
 
 // Global error logger for errorhandler

--- a/src/main/kotlin/no/nav/hm/grunndata/register/error/BadRequestErrorHandler.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/error/BadRequestErrorHandler.kt
@@ -39,7 +39,7 @@ class BadRequestErrorHandler : ExceptionHandler<BadRequestException, HttpRespons
                         .body(createMessage(error))
 
                 ErrorType.UNKNOWN -> HttpResponse.serverError(createMessage(error))
-                ErrorType.UNAUTHORIZED -> HttpResponse.unauthorized()
+                ErrorType.UNAUTHORIZED -> HttpResponse.serverError(createMessage(error))
             }
         if (error.type != ErrorType.NOT_FOUND) {
             LOG.error(response.body().toString())

--- a/src/main/kotlin/no/nav/hm/grunndata/register/importapi/ProductImportSyncRiver.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/importapi/ProductImportSyncRiver.kt
@@ -19,7 +19,8 @@ import no.nav.hm.grunndata.rapid.dto.rapidDTOVersion
 import no.nav.hm.grunndata.rapid.event.EventName
 import no.nav.hm.grunndata.rapid.event.RapidApp
 import no.nav.hm.grunndata.register.product.AdminInfo
-import no.nav.hm.grunndata.register.product.ProductRegistrationDTO
+import no.nav.hm.grunndata.register.product.ProductDTOMapper
+import no.nav.hm.grunndata.register.product.ProductRegistration
 import no.nav.hm.grunndata.register.product.ProductRegistrationEventHandler
 import no.nav.hm.grunndata.register.product.ProductRegistrationService
 import no.nav.hm.grunndata.register.product.toProductData
@@ -33,6 +34,7 @@ class ProductImportSyncRiver(
     private val objectMapper: ObjectMapper,
     private val productRegistrationService: ProductRegistrationService,
     private val productRegistrationEventHandler: ProductRegistrationEventHandler,
+    private val productDTOMapper: ProductDTOMapper,
     @Value("\${import.autoapprove}") private val autoApprove: Boolean
 ) : River.PacketListener {
 
@@ -76,7 +78,7 @@ class ProductImportSyncRiver(
                         )
                     )
                 } ?: productRegistrationService.save(
-                    ProductRegistrationDTO(
+                    ProductRegistration(
                         id = importDTO.id,
                         title = importDTO.productDTO.title,
                         articleName = importDTO.productDTO.articleName,
@@ -102,7 +104,7 @@ class ProductImportSyncRiver(
                 )
             val extraImportKeyValues =
                 mapOf("transferId" to importDTO.transferId, "version" to importDTO.version)
-            productRegistrationEventHandler.queueDTORapidEvent(registration, eventName = EventName.registeredProductV1, extraKeyValues = extraImportKeyValues)
+            productRegistrationEventHandler.queueDTORapidEvent(productDTOMapper.toDTO(registration), eventName = EventName.registeredProductV1, extraKeyValues = extraImportKeyValues)
             LOG.info(
                 """imported product ${importDTO.id} with eventId $eventId 
             |and version: ${importDTO.version} synced, adminstatus: ${registration.adminStatus}""".trimMargin()

--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductDTOMapper.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductDTOMapper.kt
@@ -1,0 +1,114 @@
+package no.nav.hm.grunndata.register.product
+
+import jakarta.inject.Singleton
+import no.nav.hm.grunndata.rapid.dto.AgreementInfo
+import no.nav.hm.grunndata.register.agreement.AgreementRegistrationService
+import no.nav.hm.grunndata.register.productagreement.ProductAgreementRegistration
+import no.nav.hm.grunndata.register.productagreement.ProductAgreementRegistrationRepository
+import no.nav.hm.grunndata.register.techlabel.TechLabelDTO
+import no.nav.hm.grunndata.register.techlabel.TechLabelService
+import java.time.LocalDateTime
+
+@Singleton
+class ProductDTOMapper(
+    private val productAgreementRegistrationRepository: ProductAgreementRegistrationRepository,
+    private val techLabelService: TechLabelService,
+    private val agreementRegistrationService: AgreementRegistrationService,
+    )
+{
+    suspend fun toDTO(productRegistration: ProductRegistration): ProductRegistrationDTO {
+        // TODO cache agreements
+        val agreements = productAgreementRegistrationRepository.findBySupplierIdAndSupplierRef(productRegistration.supplierId, productRegistration.supplierRef)
+        return ProductRegistrationDTO(
+            id = productRegistration.id,
+            supplierId = productRegistration.supplierId,
+            seriesId = productRegistration.seriesId,
+            seriesUUID = productRegistration.seriesUUID,
+            supplierRef = productRegistration.supplierRef,
+            hmsArtNr = if (!productRegistration.hmsArtNr.isNullOrBlank()) productRegistration.hmsArtNr else if (agreements.isNotEmpty()) agreements.first().hmsArtNr else null,
+            title = productRegistration.title,
+            articleName = productRegistration.articleName,
+            draftStatus = productRegistration.draftStatus,
+            adminStatus = productRegistration.adminStatus,
+            registrationStatus = productRegistration.registrationStatus,
+            message = productRegistration.message,
+            adminInfo = productRegistration.adminInfo,
+            created = productRegistration.created,
+            updated = productRegistration.updated,
+            published = productRegistration.published,
+            expired = productRegistration.expired,
+            updatedByUser = productRegistration.updatedByUser,
+            createdByUser = productRegistration.createdByUser,
+            createdBy = productRegistration.createdBy,
+            updatedBy = productRegistration.updatedBy,
+            createdByAdmin = productRegistration.createdByAdmin,
+            productData = productRegistration.productData,
+            sparePart = productRegistration.sparePart,
+            accessory = productRegistration.accessory,
+            isoCategory = productRegistration.isoCategory,
+            agreements = agreements.map { it.toAgreementInfo() },
+            version = productRegistration.version,
+        )
+    }
+
+    suspend fun toDTOV2(productRegistration: ProductRegistration): ProductRegistrationDTOV2 {
+        val agreements = productAgreementRegistrationRepository.findBySupplierIdAndSupplierRef(productRegistration.supplierId, productRegistration.supplierRef)
+        val techLabels = techLabelService.fetchLabelsByIsoCode(productRegistration.isoCategory).associateBy { it.label }
+
+        return ProductRegistrationDTOV2(
+            id = productRegistration.id,
+            seriesUUID = productRegistration.seriesUUID,
+            supplierRef = productRegistration.supplierRef,
+            hmsArtNr = if (!productRegistration.hmsArtNr.isNullOrBlank()) productRegistration.hmsArtNr else if (agreements.isNotEmpty()) agreements.first().hmsArtNr else null,
+            articleName = productRegistration.articleName,
+            productData = productRegistration.productData.toProductDataDTO(techLabels),
+            sparePart = productRegistration.sparePart,
+            created = productRegistration.created,
+            accessory = productRegistration.accessory,
+            agreements = agreements.map { it.toAgreementInfo() },
+            version = productRegistration.version,
+            isExpired = productRegistration.expired?.let { it < LocalDateTime.now() } ?: false,
+            isPublished = productRegistration.published?.let { it < LocalDateTime.now() } ?: false,
+        )
+    }
+
+    private fun ProductData.toProductDataDTO(techLabels: Map<String, TechLabelDTO>): ProductDataDTO {
+        val techdataDTOs = techLabels.map { (labelKey, techLabel) ->
+            techData.find { it.key == labelKey }?.toDTO(techLabels) ?: TechDataDTO(
+                key = labelKey,
+                value = "",
+                unit = techLabel.unit ?: "",
+                type = TechDataType.from(techLabel),
+                definition = techLabel.definition,
+                options = techLabel.options
+            )
+        }.sortedBy { it.key }
+
+        return ProductDataDTO(
+            attributes = attributes,
+            techData = techdataDTOs,
+        )
+    }
+
+    private suspend fun ProductAgreementRegistration.toAgreementInfo(): AgreementInfo {
+        val agreement =
+            agreementRegistrationService.findById(agreementId)
+                ?: throw RuntimeException("Agreement not found") // consider caching agreements
+        val delKontrakt = if (postId != null) agreement.delkontraktList.find { postId == it.id } else null
+        return AgreementInfo(
+            id = agreementId,
+            title = agreement.title,
+            identifier = agreement.agreementData.identifier,
+            rank = rank,
+            postNr = post,
+            postIdentifier = delKontrakt?.identifier,
+            postId = postId,
+            refNr = delKontrakt?.delkontraktData?.refNr,
+            published = published,
+            expired = expired,
+            reference = reference,
+            postTitle = delKontrakt?.delkontraktData?.title ?: "",
+            status = status,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductExpirePublishHandler.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductExpirePublishHandler.kt
@@ -15,7 +15,7 @@ class ProductExpirePublishHandler(private val productRegistrationService: Produc
     }
 
 
-    suspend fun expiredProducts(): List<ProductRegistrationDTO> {
+    suspend fun expiredProducts(): List<ProductRegistration> {
         val expiredProducts = productRegistrationService.findExpired()
         LOG.info("Found ${expiredProducts.size} products to be expired")
         expiredProducts.forEach {
@@ -29,7 +29,7 @@ class ProductExpirePublishHandler(private val productRegistrationService: Produc
         return expiredProducts
     }
 
-    suspend fun publishProducts(): List<ProductRegistrationDTO> {
+    suspend fun publishProducts(): List<ProductRegistration> {
         val publishing = productRegistrationService.findProductsToPublish()
         LOG.info("Found ${publishing.size} products to be published")
         publishing.forEach {

--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistration.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistration.kt
@@ -5,6 +5,7 @@ import io.micronaut.data.annotation.MappedEntity
 import io.micronaut.data.annotation.TypeDef
 import io.micronaut.data.annotation.Version
 import io.micronaut.data.model.DataType
+import io.micronaut.security.authentication.Authentication
 import jakarta.persistence.Column
 import java.time.LocalDateTime
 import java.util.UUID
@@ -63,7 +64,12 @@ data class ProductRegistration(
     val productData: ProductData,
     @field:Version
     val version: Long? = 0L,
-)
+) {
+
+    fun canChangeSupplierRef(authentication: Authentication): Boolean = authentication.isAdmin() || published == null
+
+    fun canChangeHmsArtNr(authentication: Authentication): Boolean = authentication.isAdmin()
+}
 
 data class AdminInfo(val approvedBy: String?, val note: String? = null, val approved: LocalDateTime? = null)
 

--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationAdminApiController.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationAdminApiController.kt
@@ -124,104 +124,20 @@ class ProductRegistrationAdminApiController(
             }
             ?: HttpResponse.notFound()
 
-    @Post("/draftWithV2/{seriesUUID}/supplierId/{supplierId}")
-    suspend fun draftProductWithV2(
-        @PathVariable seriesUUID: UUID,
-        @PathVariable supplierId: UUID,
-        @Body draftWith: DraftVariantDTO,
-        authentication: Authentication,
-    ): HttpResponse<ProductRegistrationDTO> =
-        try {
-            HttpResponse.ok(
-                productDTOMapper.toDTO(
-                    productRegistrationService.createDraftWithV2(
-                        seriesUUID,
-                        draftWith,
-                        authentication
-                    )
-                ),
-            )
-        } catch (e: DataAccessException) {
-            throw BadRequestException(e.message ?: "Error creating draft")
-        } catch (e: Exception) {
-            throw BadRequestException("Error creating draft")
-        }
-
     @Post("/draftWithV3/{seriesUUID}")
-    suspend fun draftProductWithV3(
+    suspend fun createDraft(
         @PathVariable seriesUUID: UUID,
-        @Body draftWith: DraftVariantDTO,
+        @Body draftVariant: DraftVariantDTO,
         authentication: Authentication,
     ): HttpResponse<ProductRegistrationDTO> =
         try {
-            HttpResponse.ok(
-                productDTOMapper.toDTO(
-                    productRegistrationService.createDraftWithV2(
-                        seriesUUID,
-                        draftWith,
-                        authentication
-                    )
-                ),
-            )
+            val variant = productRegistrationService.createDraft(seriesUUID, draftVariant, authentication)
+            HttpResponse.ok(productDTOMapper.toDTO(variant))
         } catch (e: DataAccessException) {
             throw BadRequestException(e.message ?: "Error creating draft")
         } catch (e: Exception) {
             throw BadRequestException("Error creating draft")
         }
-
-    @Post("/draft/supplier/{supplierId}{?isAccessory}{?isSparePart}")
-    suspend fun draftProduct(
-        supplierId: UUID,
-        authentication: Authentication,
-        @QueryValue(defaultValue = "false") isAccessory: Boolean,
-        @QueryValue(defaultValue = "false") isSparePart: Boolean,
-    ): HttpResponse<ProductRegistrationDTO> =
-        supplierRegistrationService.findById(supplierId)?.let {
-            try {
-                HttpResponse.ok(
-                    productDTOMapper.toDTO(
-                        productRegistrationService.createDraft(
-                            supplierId,
-                            authentication,
-                            isAccessory,
-                            isSparePart,
-                        )
-                    ),
-                )
-            } catch (e: DataAccessException) {
-                throw BadRequestException(e.message ?: "Error creating draft")
-            } catch (e: Exception) {
-                throw BadRequestException("Error creating draft")
-            }
-        } ?: throw BadRequestException("$supplierId does not exist")
-
-    @Post("/draftWith/supplier/{supplierId}{?isAccessory}{?isSparePart}")
-    suspend fun draftProductWith(
-        supplierId: UUID,
-        @QueryValue(defaultValue = "false") isAccessory: Boolean,
-        @QueryValue(defaultValue = "false") isSparePart: Boolean,
-        @Body draftWith: ProductDraftWithDTO,
-        authentication: Authentication,
-    ): HttpResponse<ProductRegistrationDTO> =
-        supplierRegistrationService.findById(supplierId)?.let {
-            try {
-                HttpResponse.ok(
-                    productDTOMapper.toDTO(
-                        productRegistrationService.createDraftWith(
-                            supplierId,
-                            authentication,
-                            isAccessory,
-                            isSparePart,
-                            draftWith,
-                        )
-                    ),
-                )
-            } catch (e: DataAccessException) {
-                throw BadRequestException(e.message ?: "Error creating draft")
-            } catch (e: Exception) {
-                throw BadRequestException("Error creating draft")
-            }
-        } ?: throw BadRequestException("$supplierId does not exist")
 
     @Post("/")
     suspend fun createProduct(

--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationAdminApiController.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationAdminApiController.kt
@@ -262,7 +262,7 @@ class ProductRegistrationAdminApiController(
     ): HttpResponse<ProductRegistrationDTO> =
         try {
             val dto = productDTOMapper.toDTO(
-                productRegistrationService.updateProductByAdminV2(
+                productRegistrationService.updateProduct(
                     registrationDTO,
                     id,
                     authentication

--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationAdminApiController.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationAdminApiController.kt
@@ -46,6 +46,7 @@ class ProductRegistrationAdminApiController(
     private val supplierRegistrationService: SupplierRegistrationService,
     private val xlImport: ProductExcelImport,
     private val xlExport: ProductExcelExport,
+    private val productDTOMapper: ProductDTOMapper,
 ) {
     companion object {
         const val API_V1_ADMIN_PRODUCT_REGISTRATIONS = "/admin/api/v1/product/registrations"
@@ -111,7 +112,7 @@ class ProductRegistrationAdminApiController(
     suspend fun getProductByIdV2(id: UUID): HttpResponse<ProductRegistrationDTOV2> =
         productRegistrationService.findByIdV2(id)
             ?.let {
-                HttpResponse.ok(it)
+                HttpResponse.ok(productDTOMapper.toDTOV2(it))
             }
             ?: HttpResponse.notFound()
 

--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationApiController.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationApiController.kt
@@ -46,6 +46,7 @@ class ProductRegistrationApiController(
     private val seriesRegistrationService: SeriesRegistrationService,
     private val xlExport: ProductExcelExport,
     private val xlImport: ProductExcelImport,
+    private val productDTOMapper: ProductDTOMapper,
 ) {
     companion object {
         const val API_V1_PRODUCT_REGISTRATIONS = "/vendor/api/v1/product/registrations"

--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationApiController.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationApiController.kt
@@ -124,7 +124,7 @@ class ProductRegistrationApiController(
         authentication: Authentication,
     ): HttpResponse<ProductRegistrationDTO> {
         try {
-            val dto = productDTOMapper.toDTO(productRegistrationService.updateProductBySupplierV2(registrationDTO, id, authentication))
+            val dto = productDTOMapper.toDTO(productRegistrationService.updateProduct(registrationDTO, id, authentication))
             return HttpResponse.ok(dto)
         } catch (dataAccessException: DataAccessException) {
             LOG.error("Got exception while updating product", dataAccessException)

--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationService.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationService.kt
@@ -51,7 +51,7 @@ open class ProductRegistrationService(
 
     open suspend fun findById(id: UUID) = productRegistrationRepository.findById(id)?.toDTO()
 
-    open suspend fun findByIdV2(id: UUID) = productRegistrationRepository.findById(id)?.toDTOV2()
+    open suspend fun findByIdV2(id: UUID) = productRegistrationRepository.findById(id)
 
     open suspend fun findByIdIn(ids: List<UUID>) = productRegistrationRepository.findByIdIn(ids).map { it.toDTO() }
 
@@ -68,8 +68,10 @@ open class ProductRegistrationService(
         )?.toDTO()
 
     open suspend fun save(dto: ProductRegistrationDTO): ProductRegistrationDTO = productRegistrationRepository.save(dto.toEntity()).toDTO()
+    open suspend fun save(dto: ProductRegistration): ProductRegistrationDTO = productRegistrationRepository.save(dto).toDTO()
 
     open suspend fun update(dto: ProductRegistrationDTO) = productRegistrationRepository.update(dto.toEntity()).toDTO()
+    open suspend fun update(dto: ProductRegistration) = productRegistrationRepository.update(dto).toDTO()
 
     open suspend fun findAll(
         spec: PredicateSpecification<ProductRegistration>?,

--- a/src/main/kotlin/no/nav/hm/grunndata/register/product/batch/ProductExcelImport.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/product/batch/ProductExcelImport.kt
@@ -12,7 +12,7 @@ import no.nav.hm.grunndata.rapid.dto.RegistrationStatus
 import no.nav.hm.grunndata.rapid.dto.TechData
 import no.nav.hm.grunndata.register.error.BadRequestException
 import no.nav.hm.grunndata.register.product.ProductData
-import no.nav.hm.grunndata.register.product.ProductRegistrationDTO
+import no.nav.hm.grunndata.register.product.ProductRegistration
 import no.nav.hm.grunndata.register.product.ProductRegistrationDryRunDTO
 import no.nav.hm.grunndata.register.techlabel.LabelService
 import no.nav.hm.grunndata.register.techlabel.TechLabelDTO
@@ -141,11 +141,11 @@ data class ProductRegistrationExcelDTO(
     val techData: List<TechData> = emptyList(),
 )
 
-fun ProductRegistrationExcelDTO.toRegistrationDTO(): ProductRegistrationDTO {
+fun ProductRegistrationExcelDTO.toProductRegistration(): ProductRegistration {
     val productId = produktid?.toUUID() ?: UUID.randomUUID()
-    val seriesUUID = produktserieid.toUUID() ?: productId
+    val seriesUUID = produktserieid.toUUID()
     val supplierId = leverandorid.toUUID()
-    return ProductRegistrationDTO(
+    return ProductRegistration(
         id = productId,
         seriesId = seriesUUID.toString(),
         seriesUUID = seriesUUID,
@@ -201,7 +201,7 @@ fun ProductRegistrationExcelDTO.toRegistrationDryRunDTO(): ProductRegistrationDr
     )
 }
 
-fun ProductRegistrationDTO.toProductRegistrationDryRunDTO(): ProductRegistrationDryRunDTO =
+fun ProductRegistration.toProductRegistrationDryRunDTO(): ProductRegistrationDryRunDTO =
     ProductRegistrationDryRunDTO(
         id = id,
         seriesUUID = seriesUUID,

--- a/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistrationService.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistrationService.kt
@@ -24,6 +24,7 @@ import no.nav.hm.grunndata.register.iso.IsoCategoryService
 import no.nav.hm.grunndata.register.media.MediaUploadService
 import no.nav.hm.grunndata.register.media.ObjectType
 import no.nav.hm.grunndata.register.product.MediaInfoDTO
+import no.nav.hm.grunndata.register.product.ProductDTOMapper
 import no.nav.hm.grunndata.register.product.ProductRegistrationService
 import no.nav.hm.grunndata.register.product.mapSuspend
 import no.nav.hm.grunndata.register.productagreement.ProductAgreementRegistrationService
@@ -42,6 +43,7 @@ open class SeriesRegistrationService(
     private val isoCategoryService: IsoCategoryService,
     private val productAgreementRegistrationService: ProductAgreementRegistrationService,
     private val mediaUploadService: MediaUploadService,
+    private val productDTOMapper: ProductDTOMapper,
 ) {
     companion object {
         private val LOG = LoggerFactory.getLogger(SeriesRegistrationService::class.java)
@@ -91,7 +93,8 @@ open class SeriesRegistrationService(
             val isoCategoryDTO = isoCategoryService.lookUpCode(seriesRegistration.isoCategory)
 
             val productRegistrationDTOs =
-                productRegistrationService.findAllBySeriesUuidV2(id).sortedBy { it.created }
+                productRegistrationService.findAllBySeriesUuid(id).sortedBy { it.created }
+                    .map { productDTOMapper.toDTOV2(it) }
 
             val inAgreement =
                 productAgreementRegistrationService.findAllByProductIds(
@@ -161,7 +164,8 @@ open class SeriesRegistrationService(
             val isoCategoryDTO = isoCategoryService.lookUpCode(seriesRegistration.isoCategory)
 
             val productRegistrationDTOs =
-                productRegistrationService.findBySeriesUUIDAndSupplierIdV2(id, supplierId).sortedBy { it.created }
+                productRegistrationService.findBySeriesUUIDAndSupplierId(id, supplierId).sortedBy { it.created }
+                    .map { productDTOMapper.toDTOV2(it) }
 
             val inAgreement =
                 productAgreementRegistrationService.findAllByProductIds(

--- a/src/main/kotlin/no/nav/hm/grunndata/register/version/CreateBaseVersionHandler.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/version/CreateBaseVersionHandler.kt
@@ -4,11 +4,10 @@ import jakarta.inject.Singleton
 import jakarta.transaction.Transactional
 import no.nav.hm.grunndata.rapid.dto.RegistrationStatus
 import no.nav.hm.grunndata.rapid.dto.SeriesStatus
-import no.nav.hm.grunndata.register.product.ProductRegistrationDTO
+import no.nav.hm.grunndata.register.product.ProductRegistration
 import no.nav.hm.grunndata.register.product.ProductRegistrationService
 import no.nav.hm.grunndata.register.product.ProductRegistrationVersion
 import no.nav.hm.grunndata.register.product.ProductRegistrationVersionService
-import no.nav.hm.grunndata.register.product.toEntity
 import no.nav.hm.grunndata.register.series.SeriesRegistrationDTO
 import no.nav.hm.grunndata.register.series.SeriesRegistrationService
 import no.nav.hm.grunndata.register.series.SeriesRegistrationVersion
@@ -90,7 +89,7 @@ open class CreateBaseVersionHandler(
             updatedBy = this.updatedBy,
         )
 
-    private fun ProductRegistrationDTO.toVersion(): ProductRegistrationVersion =
+    private fun ProductRegistration.toVersion(): ProductRegistrationVersion =
         ProductRegistrationVersion(
             productId = this.id,
             version = this.version,
@@ -98,7 +97,7 @@ open class CreateBaseVersionHandler(
             adminStatus = this.adminStatus,
             status = this.registrationStatus,
             updated = this.updated,
-            productRegistration = this.toEntity(),
+            productRegistration = this,
             updatedBy = this.updatedBy,
         )
 }

--- a/src/test/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationAdminApiTest.kt
+++ b/src/test/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationAdminApiTest.kt
@@ -7,15 +7,15 @@ import io.micronaut.security.authentication.UsernamePasswordCredentials
 import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import io.mockk.mockk
-import java.time.LocalDateTime
-import java.util.UUID
 import kotlinx.coroutines.runBlocking
 import no.nav.hm.grunndata.rapid.dto.AdminStatus
 import no.nav.hm.grunndata.rapid.dto.AgreementDTO
 import no.nav.hm.grunndata.rapid.dto.AgreementPost
 import no.nav.hm.grunndata.rapid.dto.Attributes
+import no.nav.hm.grunndata.rapid.dto.DraftStatus
 import no.nav.hm.grunndata.rapid.dto.ProductAgreementStatus
 import no.nav.hm.grunndata.rapid.dto.RegistrationStatus
+import no.nav.hm.grunndata.rapid.dto.SeriesStatus
 import no.nav.hm.grunndata.register.REGISTER
 import no.nav.hm.grunndata.register.agreement.AgreementData
 import no.nav.hm.grunndata.register.agreement.AgreementRegistration
@@ -28,6 +28,9 @@ import no.nav.hm.grunndata.register.productagreement.ProductAgreementRegistratio
 import no.nav.hm.grunndata.register.productagreement.ProductAgreementRegistrationRepository
 import no.nav.hm.grunndata.register.security.LoginClient
 import no.nav.hm.grunndata.register.security.Roles
+import no.nav.hm.grunndata.register.series.SeriesDataDTO
+import no.nav.hm.grunndata.register.series.SeriesRegistrationDTO
+import no.nav.hm.grunndata.register.series.SeriesRegistrationService
 import no.nav.hm.grunndata.register.supplier.SupplierData
 import no.nav.hm.grunndata.register.supplier.SupplierRegistrationDTO
 import no.nav.hm.grunndata.register.supplier.SupplierRegistrationService
@@ -36,15 +39,19 @@ import no.nav.hm.grunndata.register.user.UserRepository
 import no.nav.hm.rapids_rivers.micronaut.RapidPushService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.UUID
 
 @MicronautTest
-class ProductRegistrationAdminApiTest(private val apiClient: ProductRegistrationAdminApiClient,
-                                      private val loginClient: LoginClient,
-                                      private val userRepository: UserRepository,
-                                      private val supplierRegistrationService: SupplierRegistrationService,
-                                      private val agreementRegistrationRepository: AgreementRegistrationRepository,
-                                      private val productAgreementRegistrationRepository: ProductAgreementRegistrationRepository,
-                                      private val delkontraktRegistrationService: DelkontraktRegistrationService,
+class ProductRegistrationAdminApiTest(
+    private val apiClient: ProductRegistrationAdminApiClient,
+    private val loginClient: LoginClient,
+    private val userRepository: UserRepository,
+    private val supplierRegistrationService: SupplierRegistrationService,
+    private val agreementRegistrationRepository: AgreementRegistrationRepository,
+    private val productAgreementRegistrationRepository: ProductAgreementRegistrationRepository,
+    private val delkontraktRegistrationService: DelkontraktRegistrationService,
+    private val seriesRegistrationService: SeriesRegistrationService
 ) {
 
     val email = "ProductRegistrationAdminApiTest@test.test"
@@ -55,6 +62,7 @@ class ProductRegistrationAdminApiTest(private val apiClient: ProductRegistration
     val supplierRef = "eksternref-222"
     var testSupplier : SupplierRegistrationDTO? = null
     var productAgreement:  ProductAgreementRegistration? = null
+    val seriesUUID: UUID = UUID.fromString("6e8830f0-1278-4031-a9b8-08389b55cf3e")
 
     @MockBean(RapidPushService::class)
     fun rapidPushService(): RapidPushService = mockk(relaxed = true)
@@ -138,6 +146,29 @@ class ProductRegistrationAdminApiTest(private val apiClient: ProductRegistration
                     articleName = "Test article"
                 )
             )
+
+            seriesRegistrationService.save(
+                SeriesRegistrationDTO(
+                    id = seriesUUID,
+                    supplierId = supplierId,
+                    isoCategory = "",
+                    title = "",
+                    text = "",
+                    identifier = seriesUUID.toString(),
+                    draftStatus = DraftStatus.DRAFT,
+                    adminStatus = AdminStatus.PENDING,
+                    status = SeriesStatus.ACTIVE,
+                    createdBy = REGISTER,
+                    updatedBy = REGISTER,
+                    createdByUser = "",
+                    updatedByUser = "authentication.name",
+                    created = LocalDateTime.now(),
+                    updated = LocalDateTime.now(),
+                    seriesData = SeriesDataDTO(media = emptySet()),
+                    version = 0,
+                )
+            )
+
         }
     }
 
@@ -148,7 +179,7 @@ class ProductRegistrationAdminApiTest(private val apiClient: ProductRegistration
         val jwt = resp.getCookie("JWT").get().value
 
         // create a draft to begin product registration
-        val draft = apiClient.draftProduct(jwt, testSupplier!!.id)
+        val draft = apiClient.createDraft(jwt, seriesUUID, DraftVariantDTO("test", "test"))
         draft.shouldNotBeNull()
         draft.createdByAdmin shouldBe true
         draft.createdByUser shouldBe email

--- a/src/test/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationApiTest.kt
+++ b/src/test/kotlin/no/nav/hm/grunndata/register/product/ProductRegistrationApiTest.kt
@@ -164,10 +164,9 @@ class ProductRegistrationApiTest(
 
         val supplierRef = UUID.randomUUID().toString()
 
-        apiClient.createDraftWith(
+        apiClient.createDraft(
             jwt,
             seriesRegistrationSupplier1!!.id,
-            testSupplier!!.id,
             dummyDraftWith(
                 supplierRef = supplierRef,
                 articleName = "variant 1",
@@ -175,10 +174,9 @@ class ProductRegistrationApiTest(
         )
 
         assertThrows<Exception> {
-            apiClient.createDraftWith(
+            apiClient.createDraft(
                 jwt,
                 seriesRegistrationSupplier1!!.id,
-                testSupplier!!.id,
                 dummyDraftWith(
                     articleName = "variant 2",
                     supplierRef = supplierRef,
@@ -192,10 +190,9 @@ class ProductRegistrationApiTest(
         val resp = loginClient.login(UsernamePasswordCredentials(email, password))
         val jwt = resp.getCookie("JWT").get().value
 
-        val variant = apiClient.createDraftWith(
+        val variant = apiClient.createDraft(
             jwt,
             seriesRegistrationSupplier1!!.id,
-            testSupplier!!.id,
             dummyDraftWith(
                 supplierRef = UUID.randomUUID().toString(),
             ),
@@ -234,10 +231,9 @@ class ProductRegistrationApiTest(
         )
 
         val draft1 =
-            apiClient.createDraftWith(
+            apiClient.createDraft(
                 jwt,
                 seriesUUID,
-                testSupplier!!.id,
                 dummyDraftWith(
                     supplierRef = "apitest-eksternref-111",
                     articleName = "Dette er produkt 1 med og med",
@@ -273,10 +269,9 @@ class ProductRegistrationApiTest(
 
         // should not be allowed to create a product of another supplier
         runCatching {
-            apiClient.createDraftWith(
+            apiClient.createDraft(
                 jwt,
                 seriesRegistrationSupplier2!!.id,
-                testSupplier2!!.id,
                 dummyDraftWith(
                     supplierRef = "apitest-eksternref-333",
                     articleName = "Dette er produkt 1 med og med",

--- a/src/test/kotlin/no/nav/hm/grunndata/register/product/ProductiRegistrationAdminApiClient.kt
+++ b/src/test/kotlin/no/nav/hm/grunndata/register/product/ProductiRegistrationAdminApiClient.kt
@@ -6,6 +6,7 @@ import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.CookieValue
 import io.micronaut.http.annotation.Delete
 import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.PathVariable
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.Put
 import io.micronaut.http.annotation.QueryValue
@@ -31,11 +32,6 @@ interface ProductRegistrationAdminApiClient {
                      @QueryValue("page") page: Int?=null,
                      @QueryValue("sort") sort: String? = null): Page<ProductRegistrationDTO>
 
-    @Post(uri = "/", processes = [APPLICATION_JSON])
-    fun createProduct(@CookieValue("JWT") jwt: String,
-                      @Body productRegistrationDTO: ProductRegistrationDTO
-    ): ProductRegistrationDTO
-
     @Get(uri = "/{id}", produces = [APPLICATION_JSON])
     fun readProduct(@CookieValue("JWT") jwt: String, id: UUID): ProductRegistrationDTO
 
@@ -47,8 +43,11 @@ interface ProductRegistrationAdminApiClient {
     @Delete(uri="/{id}", consumes = [APPLICATION_JSON])
     fun deleteProduct(@CookieValue("JWT") jwt: String, id:UUID): ProductRegistrationDTO
 
-    @Post(uri="/draft/supplier/{supplierId}", produces = [APPLICATION_JSON])
-    fun draftProduct(@CookieValue("JWT") jwt: String, supplierId: UUID):ProductRegistrationDTO
-
+    @Post(uri = "/draftWithV3/{seriesUUID}", processes = [APPLICATION_JSON])
+    fun createDraft(
+        @CookieValue("JWT") jwt: String,
+        @PathVariable seriesUUID: UUID,
+        @Body draftVariantDTO: DraftVariantDTO,
+    ): ProductRegistrationDTO
 
 }

--- a/src/test/kotlin/no/nav/hm/grunndata/register/product/ProductiRegistrationAdminApiClient.kt
+++ b/src/test/kotlin/no/nav/hm/grunndata/register/product/ProductiRegistrationAdminApiClient.kt
@@ -39,9 +39,9 @@ interface ProductRegistrationAdminApiClient {
     @Get(uri = "/{id}", produces = [APPLICATION_JSON])
     fun readProduct(@CookieValue("JWT") jwt: String, id: UUID): ProductRegistrationDTO
 
-    @Put(uri= "/{id}", processes = [APPLICATION_JSON])
+    @Put(uri= "/v2/{id}", processes = [APPLICATION_JSON])
     fun updateProduct(@CookieValue("JWT") jwt: String, id:UUID,
-                      @Body productRegistrationDTO: ProductRegistrationDTO
+                      @Body updateProductRegistrationDTO: UpdateProductRegistrationDTO
     ): ProductRegistrationDTO
 
     @Delete(uri="/{id}", consumes = [APPLICATION_JSON])

--- a/src/test/kotlin/no/nav/hm/grunndata/register/product/ProductiRegistrationApiClient.kt
+++ b/src/test/kotlin/no/nav/hm/grunndata/register/product/ProductiRegistrationApiClient.kt
@@ -48,16 +48,16 @@ interface ProductRegistrationApiClient {
         id: UUID,
     ): ProductRegistrationDTO
 
-    @Put(uri = "/{id}", processes = [APPLICATION_JSON])
+    @Put(uri = "/v2/{id}", processes = [APPLICATION_JSON])
     fun updateProduct(
         @CookieValue("JWT") jwt: String,
         id: UUID,
-        @Body productRegistrationDTO: ProductRegistrationDTO,
+        @Body updateProductRegistrationDTO: UpdateProductRegistrationDTO
     ): ProductRegistrationDTO
 
     @Delete(uri = "/draft/delete", consumes = [APPLICATION_JSON])
     fun deleteDraftVariants(
         @CookieValue("JWT") jwt: String,
         @Body ids: List<UUID>,
-    ): ProductRegistrationDTO
+    )
 }

--- a/src/test/kotlin/no/nav/hm/grunndata/register/product/ProductiRegistrationApiClient.kt
+++ b/src/test/kotlin/no/nav/hm/grunndata/register/product/ProductiRegistrationApiClient.kt
@@ -34,11 +34,10 @@ interface ProductRegistrationApiClient {
         @QueryValue("sort") sort: String? = null,
     ): Page<ProductRegistrationDTO>
 
-    @Post(uri = "/draftWithV2/{seriesUUID}/supplierId/{supplierId}", processes = [APPLICATION_JSON])
-    fun createDraftWith(
+    @Post(uri = "/draftWithV3/{seriesUUID}", processes = [APPLICATION_JSON])
+    fun createDraft(
         @CookieValue("JWT") jwt: String,
         @PathVariable seriesUUID: UUID,
-        @PathVariable supplierId: UUID,
         @Body draftVariantDTO: DraftVariantDTO,
     ): ProductRegistrationDTO
 

--- a/src/test/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistrationControllerApiTest.kt
+++ b/src/test/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistrationControllerApiTest.kt
@@ -168,10 +168,9 @@ class SeriesRegistrationControllerApiTest(
                 )
 
             val draft1 =
-                productApiClient.createDraftWith(
+                productApiClient.createDraft(
                     jwt,
                     seriesRegistrationDTO.id,
-                    testSupplier!!.id,
                     DraftVariantDTO(
                         supplierRef = UUID.randomUUID().toString(),
                         articleName = "variant 1",

--- a/src/test/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistrationControllerApiTest.kt
+++ b/src/test/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistrationControllerApiTest.kt
@@ -9,22 +9,17 @@ import io.micronaut.security.authentication.UsernamePasswordCredentials
 import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import io.mockk.mockk
-import java.util.UUID
 import no.nav.hm.grunndata.rapid.dto.AdminStatus
 import no.nav.hm.grunndata.rapid.dto.Attributes
 import no.nav.hm.grunndata.rapid.dto.DraftStatus
 import no.nav.hm.grunndata.rapid.dto.MediaSourceType
 import no.nav.hm.grunndata.rapid.dto.MediaType
-import no.nav.hm.grunndata.rapid.dto.RegistrationStatus
 import no.nav.hm.grunndata.rapid.dto.SeriesStatus
 import no.nav.hm.grunndata.rapid.dto.TechData
-import no.nav.hm.grunndata.register.REGISTER
 import no.nav.hm.grunndata.register.product.DraftVariantDTO
 import no.nav.hm.grunndata.register.product.MediaInfoDTO
 import no.nav.hm.grunndata.register.product.ProductData
-import no.nav.hm.grunndata.register.product.ProductRegistrationAdminApiClient
 import no.nav.hm.grunndata.register.product.ProductRegistrationApiClient
-import no.nav.hm.grunndata.register.product.ProductRegistrationDTO
 import no.nav.hm.grunndata.register.security.LoginClient
 import no.nav.hm.grunndata.register.security.Roles
 import no.nav.hm.grunndata.register.supplier.SupplierData
@@ -37,6 +32,7 @@ import no.nav.hm.rapids_rivers.micronaut.RapidPushService
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 @MicronautTest
 class SeriesRegistrationControllerApiTest(
@@ -181,35 +177,7 @@ class SeriesRegistrationControllerApiTest(
                         articleName = "variant 1",
                     ),
                 )
-            val registration1 =
-                productApiClient.updateProduct(
-                    jwt,
-                    draft1.id,
-                    ProductRegistrationDTO(
-                        id = draft1.id,
-                        seriesId = updated.identifier,
-                        seriesUUID = updated.id,
-                        isoCategory = updated.isoCategory,
-                        supplierId = updated.supplierId,
-                        title = updated.title,
-                        articleName = "Dette er produkt 1 med og med",
-                        hmsArtNr = "333333",
-                        supplierRef = "eksternref-333",
-                        draftStatus = DraftStatus.DONE,
-                        adminStatus = AdminStatus.PENDING,
-                        registrationStatus = RegistrationStatus.ACTIVE,
-                        message = "Melding til leverandør",
-                        adminInfo = null,
-                        createdByAdmin = false,
-                        published = null,
-                        updatedByUser = email,
-                        createdByUser = email,
-                        productData = productData3,
-                        createdBy = REGISTER,
-                        updatedBy = REGISTER,
-                    ),
-                )
-            registration1.shouldNotBeNull()
+
             val readWithCount = apiClient.readSeries(jwt, updated.id)
             readWithCount.shouldNotBeNull()
             readWithCount.count shouldBeGreaterThanOrEqual 1
@@ -229,7 +197,7 @@ class SeriesRegistrationControllerApiTest(
             publishedSeries.status shouldBe SeriesStatus.ACTIVE
             publishedSeries.adminStatus shouldBe AdminStatus.APPROVED
 
-            val approvedVariant = productApiClient.readProduct(jwt, registration1.id)
+            val approvedVariant = productApiClient.readProduct(jwt, draft1.id)
             approvedVariant.adminStatus shouldBe AdminStatus.APPROVED
 
             val seriesInDraft = apiClient.setPublishedSeriesToDraft(jwt, updated.id)
@@ -237,7 +205,7 @@ class SeriesRegistrationControllerApiTest(
             seriesInDraft.draftStatus shouldBe DraftStatus.DRAFT
             seriesInDraft.adminStatus shouldBe AdminStatus.PENDING
 
-            val variantInDraft = productApiClient.readProduct(jwt, registration1.id)
+            val variantInDraft = productApiClient.readProduct(jwt, draft1.id)
             variantInDraft.draftStatus shouldBe DraftStatus.DRAFT
 
         }


### PR DESCRIPTION
Trukket ut dto-konverteringen til egen fil, for å kunne gjøre det utenfor Servicen.

Flyttet mesteparten av konverteringen fra ProductRegistration til ProductRegistrationDTO til Controllerene.
Har latt kafka-bruken av ProductRegistrationDTO blitt værende igjen, må sees på med tuan.

Har begynt på å flytte logikk fra Controllerene ned i servicen. Vi har mye duplisert kode, er vanligvis veldig mye likt for admin og leverandør. Har gjort det for create- og update-logikken for nå

Slettet ubrukte endepunkter for oppretting av product