### PR TITLE
Nytt endepunkt for oppdatering av serie

### DIFF
--- a/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesDTOMapper.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesDTOMapper.kt
@@ -1,0 +1,105 @@
+package no.nav.hm.grunndata.register.series
+
+import jakarta.inject.Singleton
+import java.time.LocalDateTime
+import no.nav.hm.grunndata.rapid.dto.RegistrationStatus
+import no.nav.hm.grunndata.register.HMDB
+import no.nav.hm.grunndata.register.iso.IsoCategoryService
+import no.nav.hm.grunndata.register.product.ProductDTOMapper
+import no.nav.hm.grunndata.register.product.ProductRegistrationService
+import no.nav.hm.grunndata.register.productagreement.ProductAgreementRegistrationService
+import no.nav.hm.grunndata.register.supplier.SupplierRegistrationService
+
+@Singleton
+class SeriesDTOMapper(
+    private val productAgreementRegistrationService: ProductAgreementRegistrationService,
+    private val productRegistrationService: ProductRegistrationService,
+    private val isoCategoryService: IsoCategoryService,
+    private val supplierRegistrationService: SupplierRegistrationService,
+    private val productDTOMapper: ProductDTOMapper
+) {
+
+    suspend fun toDTOV2(seriesRegistration: SeriesRegistration): SeriesRegistrationDTOV2 {
+        val supplierName = supplierRegistrationService.findById(seriesRegistration.supplierId)?.name ?: ""
+        val isoCategoryDTO = isoCategoryService.lookUpCode(seriesRegistration.isoCategory)
+        val productRegistrationDTOs = productRegistrationService.findAllBySeriesUuid(seriesRegistration.id)
+            .map { product -> productDTOMapper.toDTOV2(product) }
+        val inAgreement = productAgreementRegistrationService.findAllByProductIds(
+            productRegistrationService.findAllBySeriesUuid(seriesRegistration.id)
+                .filter { it.registrationStatus == RegistrationStatus.ACTIVE }
+                .map { it.id },
+        ).isNotEmpty()
+
+
+        return SeriesRegistrationDTOV2(
+            id = seriesRegistration.id,
+            supplierName = supplierName,
+            title = seriesRegistration.title,
+            text = seriesRegistration.text,
+            isoCategory = isoCategoryDTO,
+            message = seriesRegistration.message,
+            status = EditStatus.from(seriesRegistration),
+            seriesData = seriesRegistration.seriesData,
+            created = seriesRegistration.created,
+            updated = seriesRegistration.updated,
+            published = seriesRegistration.published,
+            expired = seriesRegistration.expired,
+            updatedByUser = seriesRegistration.updatedByUser,
+            createdByUser = seriesRegistration.createdByUser,
+            variants = productRegistrationDTOs,
+            version = seriesRegistration.version,
+            isExpired = seriesRegistration.expired < LocalDateTime.now(),
+            isPublished = seriesRegistration.published?.let { it < LocalDateTime.now() } ?: false,
+            inAgreement = inAgreement,
+            hmdbId = if (seriesRegistration.identifier != seriesRegistration.id.toString() &&
+                seriesRegistration.updatedBy == HMDB
+            ) {
+                seriesRegistration.identifier
+            } else {
+                null
+            },
+        )
+    }
+
+    suspend fun toDTOV2(seriesRegistrationDTO: SeriesRegistrationDTO): SeriesRegistrationDTOV2 {
+        val supplierName = supplierRegistrationService.findById(seriesRegistrationDTO.supplierId)?.name ?: ""
+        val isoCategoryDTO = isoCategoryService.lookUpCode(seriesRegistrationDTO.isoCategory)
+        val productRegistrationDTOs = productRegistrationService.findAllBySeriesUuid(seriesRegistrationDTO.id)
+            .map { product -> productDTOMapper.toDTOV2(product) }
+        val inAgreement = productAgreementRegistrationService.findAllByProductIds(
+            productRegistrationService.findAllBySeriesUuid(seriesRegistrationDTO.id)
+                .filter { it.registrationStatus == RegistrationStatus.ACTIVE }
+                .map { it.id },
+        ).isNotEmpty()
+
+
+        return SeriesRegistrationDTOV2(
+            id = seriesRegistrationDTO.id,
+            supplierName = supplierName,
+            title = seriesRegistrationDTO.title,
+            text = seriesRegistrationDTO.text,
+            isoCategory = isoCategoryDTO,
+            message = seriesRegistrationDTO.message,
+            status = EditStatus.from(seriesRegistrationDTO),
+            seriesData = seriesRegistrationDTO.seriesData,
+            created = seriesRegistrationDTO.created,
+            updated = seriesRegistrationDTO.updated,
+            published = seriesRegistrationDTO.published,
+            expired = seriesRegistrationDTO.expired,
+            updatedByUser = seriesRegistrationDTO.updatedByUser,
+            createdByUser = seriesRegistrationDTO.createdByUser,
+            variants = productRegistrationDTOs,
+            version = seriesRegistrationDTO.version,
+            isExpired = seriesRegistrationDTO.expired < LocalDateTime.now(),
+            isPublished = seriesRegistrationDTO.published?.let { it < LocalDateTime.now() } ?: false,
+            inAgreement = inAgreement,
+            hmdbId = if (seriesRegistrationDTO.identifier != seriesRegistrationDTO.id.toString() &&
+                seriesRegistrationDTO.updatedBy == HMDB
+            ) {
+                seriesRegistrationDTO.identifier
+            } else {
+                null
+            },
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistration.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistration.kt
@@ -268,6 +268,20 @@ enum class EditStatus {
                 throw IllegalArgumentException("Ukjent EditStatus for serie ${seriesRegistration.id}")
             }
         }
+
+        fun from(seriesRegistrationDTO: SeriesRegistrationDTO): EditStatus {
+            return if (seriesRegistrationDTO.adminStatus == AdminStatus.REJECTED) {
+                REJECTED
+            } else if (seriesRegistrationDTO.draftStatus == DraftStatus.DRAFT && seriesRegistrationDTO.adminStatus == AdminStatus.PENDING) {
+                EDITABLE
+            } else if (seriesRegistrationDTO.draftStatus == DraftStatus.DONE && seriesRegistrationDTO.adminStatus == AdminStatus.PENDING) {
+                PENDING_APPROVAL
+            } else if (seriesRegistrationDTO.adminStatus == AdminStatus.APPROVED) {
+                DONE
+            } else {
+                throw IllegalArgumentException("Ukjent EditStatus for serie ${seriesRegistrationDTO.id}")
+            }
+        }
     }
 }
 

--- a/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistration.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistration.kt
@@ -274,6 +274,8 @@ enum class EditStatus {
 data class UpdateSeriesRegistrationDTO(
     val title: String?,
     val text: String?,
+    val keywords: List<String>?,
+    val url: String?
     // val seriesData: SeriesDataDTO?,
 )
 

--- a/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistrationController.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistrationController.kt
@@ -11,6 +11,7 @@ import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Delete
 import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Patch
 import io.micronaut.http.annotation.PathVariable
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.Put
@@ -178,6 +179,14 @@ class SeriesRegistrationController(private val seriesRegistrationService: Series
             LOG.warn("Series with id $id does not exist")
             HttpResponse.notFound()
         }
+
+    @Patch("/v2/{id}")
+    suspend fun patchSeriesV2(
+        @PathVariable id: UUID,
+        @Body updateSeriesRegistrationDTO: UpdateSeriesRegistrationDTO,
+        authentication: Authentication,
+    ): HttpResponse<SeriesRegistrationDTO> =
+        HttpResponse.ok(seriesRegistrationService.patchSeries(id, updateSeriesRegistrationDTO, authentication))
 
     @Post(
         value = "/uploadMedia/{seriesUUID}",

--- a/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistrationController.kt
+++ b/src/main/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistrationController.kt
@@ -38,7 +38,10 @@ import org.reactivestreams.Publisher
 @Secured(Roles.ROLE_SUPPLIER)
 @Controller(SeriesRegistrationController.API_V1_SERIES)
 @Tag(name = "Vendor Series")
-class SeriesRegistrationController(private val seriesRegistrationService: SeriesRegistrationService) {
+class SeriesRegistrationController(
+    private val seriesRegistrationService: SeriesRegistrationService,
+    private val seriesDTOMapper: SeriesDTOMapper
+) {
     companion object {
         private val LOG = LoggerFactory.getLogger(SeriesRegistrationController::class.java)
         const val API_V1_SERIES = "/vendor/api/v1/series"
@@ -185,8 +188,16 @@ class SeriesRegistrationController(private val seriesRegistrationService: Series
         @PathVariable id: UUID,
         @Body updateSeriesRegistrationDTO: UpdateSeriesRegistrationDTO,
         authentication: Authentication,
-    ): HttpResponse<SeriesRegistrationDTO> =
-        HttpResponse.ok(seriesRegistrationService.patchSeries(id, updateSeriesRegistrationDTO, authentication))
+    ): HttpResponse<SeriesRegistrationDTOV2> =
+        HttpResponse.ok(
+            seriesDTOMapper.toDTOV2(
+                seriesRegistrationService.patchSeries(
+                    id,
+                    updateSeriesRegistrationDTO,
+                    authentication
+                )
+            )
+        )
 
     @Post(
         value = "/uploadMedia/{seriesUUID}",
@@ -207,7 +218,7 @@ class SeriesRegistrationController(private val seriesRegistrationService: Series
 
         LOG.info("supplier: ${authentication.supplierId()} uploading files for series $seriesUUID")
         seriesRegistrationService.uploadMediaAndUpdateSeries(seriesToUpdate, files)
-        
+
         return HttpResponse.ok()
     }
 

--- a/src/test/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistrationServiceTest.kt
+++ b/src/test/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistrationServiceTest.kt
@@ -70,17 +70,33 @@ class SeriesRegistrationServiceTest(
             url = "new url",
         )
 
+        val patchUpdateDTO2 = UpdateSeriesRegistrationDTO(
+            title = "newer title",
+            text = null,
+            keywords = listOf("newer keyword1", "newer keyword2"),
+            url = "newer url",
+        )
+
         val authentication = Authentication.build("marte", mapOf("supplierId" to supplierId.toString()))
 
         runBlocking {
             service.save(originalSeriesDTO)
-            
-            val patchedSeries = service.patchSeries(seriesId, patchUpdateDTO, authentication)
 
+            var patchedSeries = service.patchSeries(seriesId, patchUpdateDTO, authentication)
+
+            // same as patchDTO
             patchedSeries.title shouldBe patchUpdateDTO.title
             patchedSeries.text shouldBe patchUpdateDTO.text
             patchedSeries.seriesData.attributes.keywords shouldBe patchUpdateDTO.keywords
             patchedSeries.seriesData.attributes.url shouldBe patchUpdateDTO.url
+
+            // text should be old value
+            patchedSeries = service.patchSeries(seriesId, patchUpdateDTO2, authentication)
+
+            patchedSeries.title shouldBe patchUpdateDTO2.title
+            patchedSeries.text shouldBe patchUpdateDTO.text
+            patchedSeries.seriesData.attributes.keywords shouldBe patchUpdateDTO2.keywords
+            patchedSeries.seriesData.attributes.url shouldBe patchUpdateDTO2.url
 
         }
     }

--- a/src/test/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistrationServiceTest.kt
+++ b/src/test/kotlin/no/nav/hm/grunndata/register/series/SeriesRegistrationServiceTest.kt
@@ -1,0 +1,87 @@
+package no.nav.hm.grunndata.register.series
+
+import io.kotest.common.runBlocking
+import io.kotest.matchers.shouldBe
+import io.micronaut.security.authentication.Authentication
+import io.micronaut.test.annotation.MockBean
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import io.mockk.mockk
+import java.time.LocalDateTime
+import java.util.UUID
+import no.nav.hm.grunndata.rapid.dto.AdminStatus
+import no.nav.hm.grunndata.rapid.dto.DraftStatus
+import no.nav.hm.grunndata.rapid.dto.MediaSourceType
+import no.nav.hm.grunndata.rapid.dto.MediaType
+import no.nav.hm.grunndata.rapid.dto.SeriesStatus
+import no.nav.hm.grunndata.register.product.MediaInfoDTO
+import no.nav.hm.rapids_rivers.micronaut.RapidPushService
+import org.junit.jupiter.api.Test
+
+@MicronautTest
+class SeriesRegistrationServiceTest(
+    private val service: SeriesRegistrationService,
+    private val repository: SeriesRegistrationRepository
+) {
+    @MockBean(RapidPushService::class)
+    fun rapidPushService(): RapidPushService = mockk(relaxed = true)
+
+
+    @Test
+    fun patchSeries() {
+        val seriesId = UUID.randomUUID()
+        val supplierId = UUID.randomUUID()
+
+        val originalSeries = SeriesRegistration(
+            id = seriesId,
+            supplierId = supplierId,
+            identifier = "identifier",
+            title = "title",
+            text = "text",
+            isoCategory = "12345678",
+            draftStatus = DraftStatus.DRAFT,
+            status = SeriesStatus.ACTIVE,
+            adminStatus = AdminStatus.PENDING,
+            seriesData = SeriesDataDTO(
+                media = setOf(
+                    MediaInfoDTO(
+                        sourceUri = "sourceUri",
+                        filename = "filename",
+                        uri = "uri",
+                        priority = 1,
+                        type = MediaType.IMAGE,
+                        text = "text",
+                        source = MediaSourceType.REGISTER,
+                        updated = LocalDateTime.now(),
+                    )
+                ),
+                attributes = SeriesAttributesDTO(
+                    keywords = listOf("keyword1", "keyword2"),
+                    url = "url",
+                )
+            )
+        )
+
+        val originalSeriesDTO = originalSeries.toDTO()
+
+        val patchUpdateDTO = UpdateSeriesRegistrationDTO(
+            title = "new title",
+            text = "new text",
+            keywords = listOf("new keyword1", "new keyword2"),
+            url = "new url",
+        )
+
+        val authentication = Authentication.build("marte", mapOf("supplierId" to supplierId.toString()))
+
+        runBlocking {
+            service.save(originalSeriesDTO)
+            
+            val patchedSeries = service.patchSeries(seriesId, patchUpdateDTO, authentication)
+
+            patchedSeries.title shouldBe patchUpdateDTO.title
+            patchedSeries.text shouldBe patchUpdateDTO.text
+            patchedSeries.seriesData.attributes.keywords shouldBe patchUpdateDTO.keywords
+            patchedSeries.seriesData.attributes.url shouldBe patchUpdateDTO.url
+
+        }
+    }
+}


### PR DESCRIPTION
nytt endepunkt for å oppdatere serie-informasjon
føles litt hacky ut med all sjekk for null-tingene, men som en start til å gå over til dette virker det ok
også start på en dto-mapper for SeriesRegistration-objekter, tenkte å flytte alt som blir mappa i SeriesRegistrationService til denne.